### PR TITLE
FIX: fetching index repodata - SSL cert failure

### DIFF
--- a/boa/cli/mambabuild.py
+++ b/boa/cli/mambabuild.py
@@ -12,6 +12,7 @@ from conda_build.conda_interface import get_rc_urls
 from conda_build.index import update_index
 
 from boa.core.solver import MambaSolver
+from mamba.utils import init_api_context
 
 only_dot_or_digit_re = re.compile(r"^[\d\.]+$")
 
@@ -60,6 +61,8 @@ def main():
 
     config = Config(**args)
     channel_urls = get_rc_urls() + get_channel_urls({})
+
+    init_api_context()
 
     print(f"Updating build index: {(config.output_folder)}\n")
     update_index(config.output_folder, verbose=config.debug, threads=1)


### PR DESCRIPTION
I've been experimenting with `mamba` in a company / corporate environment behind proxies.

Today I tried for the first time to use `boa` to build conda packages. It failed with the error message `SSL peer certificate or SSH remote key was not OK` when trying to update the index after calling the `get_index()` function on the mamba's `utils.py` module, when trying to call:

```python
dlist.download(True)
```

I looked at `mamba` source code, and I noticed that before many commands (for example, `install`) are executed there is a call to `init_api_context()`.

I added that call in the beginning of the `mambabuild` command and it worked: the build passed.

However so far I've noticed it's always getting from cached data.

So I'm not sure if this is the final solution to the problem.