### PR TITLE
FIX: solver lookup for noarch

### DIFF
--- a/boa/core/solver.py
+++ b/boa/core/solver.py
@@ -14,7 +14,6 @@ from conda_build.conda_interface import pkgs_dirs
 from conda.models.channel import Channel
 from conda.core.package_cache_data import PackageCacheData
 
-from boa.core.utils import normalize_subdir
 from mamba import mamba_api
 from mamba.utils import get_index, load_channels, to_package_record_from_subjson
 
@@ -29,9 +28,9 @@ def refresh_solvers():
 
 def get_solver(subdir):
     pkg_cache = PackageCacheData.first_writable().pkgs_dir
-    subdir = normalize_subdir(subdir)
-
-    if subdir != context.subdir:
+    if subdir == "noarch":
+        subdir = context.subdir
+    elif subdir != context.subdir:
         pkg_cache = os.path.join(pkg_cache, subdir)
         if not os.path.exists(pkg_cache):
             os.makedirs(pkg_cache, exist_ok=True)

--- a/boa/core/solver.py
+++ b/boa/core/solver.py
@@ -14,7 +14,7 @@ from conda_build.conda_interface import pkgs_dirs
 from conda.models.channel import Channel
 from conda.core.package_cache_data import PackageCacheData
 
-
+from boa.core.utils import normalize_subdir
 from mamba import mamba_api
 from mamba.utils import get_index, load_channels, to_package_record_from_subjson
 
@@ -29,10 +29,9 @@ def refresh_solvers():
 
 def get_solver(subdir):
     pkg_cache = PackageCacheData.first_writable().pkgs_dir
-    if subdir == "noarch":
-        # actually use platform subdir ...
-        subdir = context.subdir
-    elif subdir != context.subdir:
+    subdir = normalize_subdir(subdir)
+
+    if subdir != context.subdir:
         pkg_cache = os.path.join(pkg_cache, subdir)
         if not os.path.exists(pkg_cache):
             os.makedirs(pkg_cache, exist_ok=True)

--- a/boa/core/utils.py
+++ b/boa/core/utils.py
@@ -1,6 +1,7 @@
 import collections
 import sys
 
+from conda.base.context import context
 from conda_build import utils
 from conda_build.config import get_or_merge_config
 from conda_build.variants import find_config_files, parse_config_file
@@ -43,3 +44,11 @@ def get_config(folder, variant=None):
         cbc = {}
 
     return cbc, config
+
+
+def normalize_subdir(subdir):
+    if subdir == "noarch":
+        subdir = context.subdir
+    else:
+        return subdir
+

--- a/boa/core/utils.py
+++ b/boa/core/utils.py
@@ -51,4 +51,3 @@ def normalize_subdir(subdir):
         subdir = context.subdir
     else:
         return subdir
-


### PR DESCRIPTION
This is the proposed fix for #111 

Thanks @wolfv for the help and the guidance here.

I couldn't easily reuse the existing `get_solver()` function from `solver.py` because I wasn't sure about the current behaviour there when it creates the solvers for the first time, it's passing an empty list of channel_urls, which is different from the behaviour when calling from `mamba_get_install_actions()`.
