### PR TITLE
Refactoring to extract a minimal mambabuild API

### DIFF
--- a/boa/cli/mambabuild.py
+++ b/boa/cli/mambabuild.py
@@ -136,4 +136,4 @@ def main():
 
     action = "test" if args.test else "build"
 
-    return call_conda_build(action, config)
+    call_conda_build(action, config)


### PR DESCRIPTION
@wolfv as we discussed I'm extracting here the 2 methods `prepare()` and `call_conda_build()` to make it easier to call `mambabuild` programatically without requiring duplicating the same code elsewhere. Now `main()` is just a glue function that calls the preparation steps, gets the Config returned and delegates it to `conda-build`.