### PR TITLE
Fix MambaSolver ignoring set pkgs_dirs

### DIFF
--- a/boa/cli/boa.py
+++ b/boa/cli/boa.py
@@ -6,6 +6,7 @@ from boa.cli import convert
 from boa.cli import transmute
 from boa.cli import validate
 
+from mamba.utils import init_api_context
 from rich.console import Console
 
 console = Console()
@@ -77,6 +78,8 @@ def main(config=None):
     args = parser.parse_args()
 
     command = args.command
+
+    init_api_context()
 
     if command == "convert":
         convert.main(args.target)

--- a/boa/core/solver.py
+++ b/boa/core/solver.py
@@ -99,15 +99,6 @@ def get_virtual_packages():
 
 class MambaSolver:
     def __init__(self, channels, platform, output_folder=None):
-
-        api_ctx = mamba_api.Context()
-        api_ctx.root_prefix = context.conda_prefix
-        api_ctx.conda_prefix = context.conda_prefix
-        # api_ctx.set_verbosity(1)
-        api_ctx.offline = context.offline
-        api_ctx.envs_dirs = [os.path.join(context.conda_prefix, "envs")]
-        api_ctx.pkgs_dirs = [os.path.join(context.conda_prefix, "pkgs")]
-
         self.channels = channels
         self.platform = platform
         self.output_folder = output_folder or "local"


### PR DESCRIPTION
Remove redundant setting of `api_ctx` now that it's done by calling `mamba.utils.init_api_context` in `mambabuild`.

Resolves the issue detailed here: https://github.com/mamba-org/boa/issues/124