### PR TITLE
Fix run constrains metadata

### DIFF
--- a/boa/core/metadata.py
+++ b/boa/core/metadata.py
@@ -418,7 +418,7 @@ class MetaData:
         # conda 4.4+ optional dependencies
         constrains = ensure_list(self.get_value("requirements/run_constrained"))
         # filter None values
-        constrains = [v for v in constrains if v]
+        constrains = [str(v) for v in constrains if v]
         if constrains:
             d["constrains"] = constrains
 

--- a/boa/core/recipe_output.py
+++ b/boa/core/recipe_output.py
@@ -236,6 +236,7 @@ class Output:
             self.requirements[section] = [
                 CondaBuildSpec(r) for r in (self.requirements.get(section) or [])
             ]
+        self.sections["requirements"] = self.requirements
 
         # handle strong and weak run exports
         run_exports = []
@@ -448,6 +449,10 @@ class Output:
         if self.requirements["run"]:
             add_header("Run", True)
             for r in self.requirements["run"]:
+                spec_format(r)
+        if self.requirements["run_constrained"]:
+            add_header("Run Constraints", True)
+            for r in self.requirements["run_constrained"]:
                 spec_format(r)
         return table
 


### PR DESCRIPTION
This properly adds constrains metadata when `run_constrained` is in metadata.