### PR TITLE
Install mamba in the dev environment as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Runs a "build" of the v2 recipe.
 
 Install the boa dependencies:
 ```
-mamba install "conda-build>=3.20" colorama pip ruamel ruamel.yaml rich mamba -c conda-forge
+mamba install "conda-build>=3.20" colorama pip ruamel ruamel.yaml rich mamba jsonschema -c conda-forge
 ```
 
 Now install boa:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Runs a "build" of the v2 recipe.
 
 Install the boa dependencies:
 ```
-mamba install "conda-build>=3.20" colorama pip ruamel ruamel.yaml rich -c conda-forge
+mamba install "conda-build>=3.20" colorama pip ruamel ruamel.yaml rich mamba -c conda-forge
 ```
 
 Now install boa:


### PR DESCRIPTION
`boa` depends on `mamba`.
We get `ModuleNotFoundError: No module named 'mamba.utils'` if `mamba` is not installed in the environment.