### PR TITLE
remove clobber warnings in boa interactive build

### DIFF
--- a/boa/core/recipe_output.py
+++ b/boa/core/recipe_output.py
@@ -601,9 +601,22 @@ class Output:
             else:
                 subdir = self.config.build_subdir
 
-            solver, pkg_cache = get_solver(
-                subdir, self.config.host_prefix, output_folder=self.config.output_folder
-            )
+            if env == "host":
+                solver, pkg_cache = get_solver(
+                    subdir,
+                    self.config.host_prefix,
+                    output_folder=self.config.output_folder,
+                )
+            elif env == "build":
+                solver, pkg_cache = get_solver(
+                    subdir,
+                    self.config.build_prefix,
+                    output_folder=self.config.output_folder,
+                )
+            else:
+                solver, pkg_cache = get_solver(
+                    subdir, output_folder=self.config.output_folder
+                )
             t = solver.solve(specs, [pkg_cache])
 
             _, install_pkgs, _ = t.to_conda()

--- a/boa/core/recipe_output.py
+++ b/boa/core/recipe_output.py
@@ -602,7 +602,7 @@ class Output:
                 subdir = self.config.build_subdir
 
             solver, pkg_cache = get_solver(
-                subdir, output_folder=self.config.output_folder
+                subdir, self.config, output_folder=self.config.output_folder
             )
             t = solver.solve(specs, [pkg_cache])
 

--- a/boa/core/recipe_output.py
+++ b/boa/core/recipe_output.py
@@ -601,22 +601,13 @@ class Output:
             else:
                 subdir = self.config.build_subdir
 
+            solver, pkg_cache = get_solver(
+                subdir, output_folder=self.config.output_folder
+            )
             if env == "host":
-                solver, pkg_cache = get_solver(
-                    subdir,
-                    self.config.host_prefix,
-                    output_folder=self.config.output_folder,
-                )
+                solver.replace_installed(self.config.host_prefix)
             elif env == "build":
-                solver, pkg_cache = get_solver(
-                    subdir,
-                    self.config.build_prefix,
-                    output_folder=self.config.output_folder,
-                )
-            else:
-                solver, pkg_cache = get_solver(
-                    subdir, output_folder=self.config.output_folder
-                )
+                solver.replace_installed(self.config.build_prefix)
             t = solver.solve(specs, [pkg_cache])
 
             _, install_pkgs, _ = t.to_conda()

--- a/boa/core/recipe_output.py
+++ b/boa/core/recipe_output.py
@@ -602,7 +602,7 @@ class Output:
                 subdir = self.config.build_subdir
 
             solver, pkg_cache = get_solver(
-                subdir, self.config, output_folder=self.config.output_folder
+                subdir, self.config.host_prefix, output_folder=self.config.output_folder
             )
             t = solver.solve(specs, [pkg_cache])
 

--- a/boa/core/solver.py
+++ b/boa/core/solver.py
@@ -25,12 +25,11 @@ from boa.core.config import boa_config
 
 console = boa_config.console
 
-solver_cache = {}
 solvers = []
 
 
 def refresh_solvers():
-    for _, v in solver_cache.items():
+    for v in solvers:
         v.replace_channels()
 
 

--- a/boa/core/solver.py
+++ b/boa/core/solver.py
@@ -34,7 +34,7 @@ def refresh_solvers():
         v.replace_channels()
 
 
-def get_solver(subdir, prefix, output_folder="local"):
+def get_solver(subdir, prefix=None, output_folder="local"):
     pkg_cache = PackageCacheData.first_writable().pkgs_dir
     if subdir == "noarch":
         subdir = context.subdir
@@ -116,7 +116,7 @@ def get_virtual_packages():
 
 
 class MambaSolver:
-    def __init__(self, channels, platform, prefix, output_folder=None):
+    def __init__(self, channels, platform, prefix=None, output_folder=None):
         self.channels = channels
         self.platform = platform
         self.prefix = prefix
@@ -128,11 +128,15 @@ class MambaSolver:
         )
 
         # if platform == context.subdir:
-        prefix_data = mamba_api.PrefixData(self.prefix)
-        vp = mamba_api.get_virtual_packages()
-        prefix_data.add_virtual_packages(vp)
-        prefix_data.load()
-        repo = mamba_api.Repo(self.pool, prefix_data)
+        if self.prefix:
+            prefix_data = mamba_api.PrefixData(self.prefix)
+            vp = mamba_api.get_virtual_packages()
+            prefix_data.add_virtual_packages(vp)
+            prefix_data.load()
+            repo = mamba_api.Repo(self.pool, prefix_data)
+        else:
+            installed_json_f = get_virtual_packages()
+            repo = mamba_api.Repo(self.pool, "installed", installed_json_f.name, "")
         repo.set_installed()
         self.repos.append(repo)
 

--- a/boa/core/solver.py
+++ b/boa/core/solver.py
@@ -25,11 +25,11 @@ from boa.core.config import boa_config
 
 console = boa_config.console
 
-solvers = []
+solver_cache = {}
 
 
 def refresh_solvers():
-    for v in solvers:
+    for _, v in solver_cache.items():
         v.replace_channels()
 
 
@@ -42,10 +42,10 @@ def get_solver(subdir, output_folder="local"):
         if not os.path.exists(pkg_cache):
             os.makedirs(pkg_cache, exist_ok=True)
 
-    m_solver = MambaSolver([], subdir, output_folder)
-    solvers.append(m_solver)
+    if not solver_cache.get(subdir):
+        solver_cache[subdir] = MambaSolver([], subdir, output_folder)
 
-    return m_solver, pkg_cache
+    return solver_cache[subdir], pkg_cache
 
 
 def get_url_from_channel(c):

--- a/boa/core/solver.py
+++ b/boa/core/solver.py
@@ -115,7 +115,7 @@ def get_virtual_packages():
 
 
 class MambaSolver:
-    def __init__(self, channels, platform, prefix=None, output_folder=None):
+    def __init__(self, channels, platform, output_folder=None):
         self.channels = channels
         self.platform = platform
         self.output_folder = output_folder or "local"

--- a/boa/core/test.py
+++ b/boa/core/test.py
@@ -491,9 +491,7 @@ def run_test(
     utils.rm_rf(metadata.config.test_prefix)
 
     if solver is None:
-        solver, pkg_cache_path = get_solver(
-            metadata.config.host_subdir, metadata.config.host_prefix
-        )
+        solver, pkg_cache_path = get_solver(metadata.config.host_subdir)
     else:
         pkg_cache_path = PackageCacheData.first_writable().pkgs_dir
 

--- a/boa/core/test.py
+++ b/boa/core/test.py
@@ -491,7 +491,9 @@ def run_test(
     utils.rm_rf(metadata.config.test_prefix)
 
     if solver is None:
-        solver, pkg_cache_path = get_solver(metadata.config.host_subdir)
+        solver, pkg_cache_path = get_solver(
+            metadata.config.host_subdir, metadata.config
+        )
     else:
         pkg_cache_path = PackageCacheData.first_writable().pkgs_dir
 

--- a/boa/core/test.py
+++ b/boa/core/test.py
@@ -492,7 +492,7 @@ def run_test(
 
     if solver is None:
         solver, pkg_cache_path = get_solver(
-            metadata.config.host_subdir, metadata.config
+            metadata.config.host_subdir, metadata.config.host_prefix
         )
     else:
         pkg_cache_path = PackageCacheData.first_writable().pkgs_dir


### PR DESCRIPTION
A few comments:

1. Clobber Warnings still appear :/
2. New output also appears in the form of:
```
INFO: activate_clang_osx-64.sh made the following environmental changes:
+AR=x86_64-apple-darwin13.4.0-ar
+AS=x86_64-apple-darwin13.4.0-as
+CC=x86_64-apple-darwin13.4.0-clang
...
```
3. Returning `MambaSolver([], subdir, config, output_folder)` directly instead of using caching somehow breaks the
    `boa build -i` with a segmentation fault.