### PR TITLE
Pass --quiet from mambabuild to boa

### DIFF
--- a/boa/cli/mambabuild.py
+++ b/boa/cli/mambabuild.py
@@ -97,6 +97,9 @@ def prepare(**kwargs):
     config = Config(**kwargs)
     config.channel_urls = get_channel_urls(kwargs)
 
+    if config.quiet:
+        suppress_stdout()
+
     init_api_context()
 
     config.output_folder = os.path.abspath(config.output_folder)


### PR DESCRIPTION
This PR attempts to support `conda mambabuild --quiet ...` by using the existing `suppress_stdout` function.