### PR TITLE
Fix format of conda mambabuild --output

### DIFF
--- a/boa/cli/mambabuild.py
+++ b/boa/cli/mambabuild.py
@@ -180,7 +180,7 @@ def call_conda_build(action, config, **kwargs):
     if action == "output":
         suppress_stdout()
         result = api.get_output_file_paths(recipe, config=config, **kwargs)
-        print('\n'.join(sorted(result)))
+        print("\n".join(sorted(result)))
     elif action == "test":
         result = api.test(recipe, config=config, **kwargs)
     elif action == "build":

--- a/boa/cli/mambabuild.py
+++ b/boa/cli/mambabuild.py
@@ -180,7 +180,7 @@ def call_conda_build(action, config, **kwargs):
     if action == "output":
         suppress_stdout()
         result = api.get_output_file_paths(recipe, config=config, **kwargs)
-        print(result)
+        print('\n'.join(sorted(result)))
     elif action == "test":
         result = api.test(recipe, config=config, **kwargs)
     elif action == "build":


### PR DESCRIPTION
This PR fixes the format of the `--output` action for `mambabuild` to match conda-build.