### PR TITLE
mambabuild --test support for multiple files

### DIFF
--- a/boa/cli/mambabuild.py
+++ b/boa/cli/mambabuild.py
@@ -182,7 +182,23 @@ def call_conda_build(action, config, **kwargs):
         result = api.get_output_file_paths(recipe, config=config, **kwargs)
         print("\n".join(sorted(result)))
     elif action == "test":
-        result = api.test(recipe, config=config, **kwargs)
+        failed_recipes = []
+        recipes = [item for sublist in [glob(os.path.abspath(recipe)) if '*' in recipe else [recipe] for recipe in config.recipe] for item in sublist]
+        for recipe in recipes:
+            try:
+                result = api.test(recipe, config=config, **kwargs)
+            except:
+                failed_recipes.append(recipe)
+                continue
+        if failed_recipes:
+            print("Failed recipes:")
+            for recipe in failed_recipes:
+                print("  - %s" % recipe)
+            sys.exit(len(failed_recipes))
+        else:
+            print("All tests passed")
+        result = []
+        
     elif action == "build":
         result = api.build(
             recipe,


### PR DESCRIPTION
This adds support for testing multiple files as reported in #224 

Solution is to handle it the same way that `conda-build` does here: https://github.com/conda/conda-build/blob/4ec7d8a7625649b555abc1aad000a141e9d067c5/conda_build/cli/main_build.py#L443-L464

Its not beautiful but works