### PR TITLE
Fix error if noarch bundles a library

### DIFF
--- a/boa/core/build.py
+++ b/boa/core/build.py
@@ -33,6 +33,7 @@ from conda_build.index import update_index
 from conda_build.post import (
     post_process,
     post_build,
+    filetypes_for_platform,
     fix_permissions,
     get_build_metadata,
 )
@@ -71,6 +72,10 @@ from conda_build.build import (
 from rich.prompt import Confirm
 
 console = boa_config.console
+
+
+# Avoid error when checking overlinking if noarch package bundles a library
+filetypes_for_platform["noarch"] = []
 
 
 def create_post_scripts(m):


### PR DESCRIPTION
If a noarch package happens to contain a library boa fails when conda build checks if overlinking.  This is a simple workaround (that fixes the build locally).

```
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│                                                                              │
│ /home/runner/micromamba/envs/conda-mobile/lib/python3.10/site-packages/boa/c │
│ ore/run_build.py:569 in build_recipe                                         │
│                                                                              │
│   566 │   │   │   │   f"\n[yellow]Starting build for [bold]{o.name}[/bold][/ │
│   567 │   │   │   )                                                          │
│   568 │   │   │                                                              │
│ ❱ 569 │   │   │   final_outputs = build(                                     │
│   570 │   │   │   │   meta,                                                  │
│   571 │   │   │   │   None,                                                  │
│   572 │   │   │   │   allow_interactive=interactive,                         │
│ /home/runner/micromamba/envs/conda-mobile/lib/python3.10/site-packages/boa/c │
│ ore/build.py:656 in build                                                    │
│                                                                              │
│   653 │   │   │   utils.rm_rf(m.config.host_prefix)                          │
│   654 │   │   │   return                                                     │
│   655 │   │                                                                  │
│ ❱ 656 │   │   final_outputs = bundle_conda(                                  │
│   657 │   │   │   m, files_before_script, env, m.output.sections["files"]    │
│   658 │   │   )                                                              │
│   659 │   │   return final_outputs                                           │
│                                                                              │
│ /home/runner/micromamba/envs/conda-mobile/lib/python3.10/site-packages/boa/c │
│ ore/build.py:240 in bundle_conda                                             │
│                                                                              │
│   237                                                                        │
│   238 def bundle_conda(metadata, initial_files, env, files_selector=None):   │
│   239 │                                                                      │
│ ❱ 240 │   files = post_process_files(metadata, initial_files)                │
│   241 │                                                                      │
│   242 │   # first filter is so that info_files does not pick up ignored file │
│   243 │   files = utils.filter_files(files, prefix=metadata.config.host_pref │
│                                                                              │
│ /home/runner/micromamba/envs/conda-mobile/lib/python3.10/site-packages/boa/c │
│ ore/build.py:197 in post_process_files                                       │
│                                                                              │
│   194 │   │   │   │   % meta_files                                           │
│   195 │   │   │   )                                                          │
│   196 │   │   )                                                              │
│ ❱ 197 │   post_build(m, new_files, build_python=python)                      │
│   198 │                                                                      │
│   199 │   entry_point_script_names = get_entry_point_script_names(           │
│   200 │   │   m.get_value("build/entry_points")                              │
│                                                                              │
│ /home/runner/micromamba/envs/conda-mobile/lib/python3.10/site-packages/conda │
│ _build/post.py:1318 in post_build                                            │
│                                                                              │
│   1315 │   │   │   if binary_relocation is True or (isinstance(binary_reloca │
│   1316 │   │   │   │   │   │   │   │   │   │   │    f in binary_relocation): │
│   1317 │   │   │   │   post_process_shared_lib(m, f, prefix_files, host_pref │
│ ❱ 1318 │   check_overlinking(m, files, host_prefix)                          │
│   1319                                                                       │
│   1320                                                                       │
│   1321 def check_symlinks(files, prefix, croot):                             │
│                                                                              │
│ /home/runner/micromamba/envs/conda-mobile/lib/python3.10/site-packages/conda │
│ _build/post.py:1224 in check_overlinking                                     │
│                                                                              │
│   1221 def check_overlinking(m, files, host_prefix=None):                    │
│   1222 │   if not host_prefix:                                               │
│   1223 │   │   host_prefix = m.config.host_prefix                            │
│ ❱ 1224 │   return check_overlinking_impl(m.get_value('package/name'),        │
│   1225 │   │   │   │   │   │   │   │     m.get_value('package/version'),     │
│   1226 │   │   │   │   │   │   │   │     m.get_value('build/string'),        │
│   1227 │   │   │   │   │   │   │   │     m.get_value('build/number'),        │
│                                                                              │
│ /home/runner/micromamba/envs/conda-mobile/lib/python3.10/site-packages/conda │
│ _build/post.py:1037 in check_overlinking_impl                                │
│                                                                              │
│   1034 │   for f in files:                                                   │
│   1035 │   │   path = join(run_prefix, f)                                    │
│   1036 │   │   filetype = codefile_type(path)                                │
│ ❱ 1037 │   │   if filetype and filetype in filetypes_for_platform[subdir.spl │
│   1038 │   │   │   files_to_inspect.append(f)                                │
│   1039 │   │   filesu.append(f.replace('\\', '/'))                           │
│   1040                                                                       │
╰──────────────────────────────────────────────────────────────────────────────╯
KeyError: 'noarch'
Error: Process completed with exit code 1.

```

As as side note, boa builds about 2 minutes faster per recipe than conda. Nice work!