### PR TITLE
Fix AttributeError in conda_build_spec in case there is no pin

### DIFF
--- a/boa/core/conda_build_spec.py
+++ b/boa/core/conda_build_spec.py
@@ -154,7 +154,7 @@ class CondaBuildSpec:
         version = output.version
         build_string = output.final_build_id
 
-        if self.pin.exact:
+        if self.is_pin and self.pin.exact:
             self.final = f"{pkg_name} {version} {build_string}"
         else:
             version_parts = version.split(".")


### PR DESCRIPTION
A simple recipe like https://github.com/RoboStack/ros-galactic/tree/main/additional_recipes/ros2-distro-mutex fails with:
```bash
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│                                                                                                  │
│ /Users/fischert/mambaforge/lib/python3.9/site-packages/boa/core/run_build.py:302 in build_recipe │
│                                                                                                  │
│   299 │   │   │   o.finalize_solve(sorted_outputs)                                               │
│   300 │   │   │                                                                                  │
│   301 │   │   │   meta = MetaData(recipe_path, o)                                                │
│ ❱ 302 │   │   │   o.set_final_build_id(meta)                                                     │
│   303 │   │   │                                                                                  │
│   304 │   │   │   if o.skip() or full_render:                                                    │
│   305 │   │   │   │   continue                                                                   │
│ /Users/fischert/mambaforge/lib/python3.9/site-packages/boa/core/recipe_output.py:576 in          │
│ set_final_build_id                                                                               │
│                                                                                                  │
│   573 │   │   │   │   │   # remove self-run-exports for static packages                          │
│   574 │   │   │   │   │   run_exports_list[:] = []                                               │
│   575 │   │   │   │   else:                                                                      │
│ ❱ 576 │   │   │   │   │   x.eval_pin_subpackage([self])                                          │
│   577 │   │   │   │                                                                              │
│   578 │   │   │   │   x.eval_pin_subpackage([self])                                              │
│   579 │   │   │   run_exports_list[:] = [x.final for x in run_exports_list]                      │
│                                                                                                  │
│ /Users/fischert/mambaforge/lib/python3.9/site-packages/boa/core/conda_build_spec.py:157 in       │
│ eval_pin_subpackage                                                                              │
│                                                                                                  │
│   154 │   │   version = output.version                                                           │
│   155 │   │   build_string = output.final_build_id                                               │
│   156 │   │                                                                                      │
│ ❱ 157 │   │   if self.pin.exact:                                                                 │
│   158 │   │   │   self.final = f"{pkg_name} {version} {build_string}"                            │
│   159 │   │   else:                                                                              │
│   160 │   │   │   version_parts = version.split(".")                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'NoneType' object has no attribute 'exact'
```