### PR TITLE
Update metadata.py

### DIFF
--- a/boa/core/metadata.py
+++ b/boa/core/metadata.py
@@ -403,7 +403,7 @@ class MetaData:
             arch=ARCH_MAP.get(arch, arch),
             subdir=self.config.target_subdir,
             depends=sorted(
-                " ".join(ms.final.split(" ")[:2]) for ms in self.ms_depends()
+                " ".join(ms.final.split(" ")[:3]) for ms in self.ms_depends()
             ),
             timestamp=int(time.time() * 1000),
         )


### PR DESCRIPTION
When recipe.yaml uses a build string in addition to the dependent pkg version, the build string is not propagated to the resulting pkg. this will result in an different dependency resolution at pkg install time as the build string is no longer part of the pkg dependency