### PR TITLE
Support additional conda-build command line flags in `boa build`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,9 @@ repos:
     rev: 3.8.3
     hooks:
     -   id: flake8
+        args:
+            # used by flake8-typing-imports
+            - "--min-python-version=3.7.0"
         exclude: tests/data
         language_version: python3
         additional_dependencies:

--- a/boa/cli/boa.py
+++ b/boa/cli/boa.py
@@ -93,6 +93,67 @@ def main(config=None):
         action="store_true",
         help="Continue building remaining recipes if a recipe fails.",
     )
+    # The following arguments are taken directly from conda-build
+    conda_build_parser = build_parser.add_argument_group("special conda-build flags")
+    conda_build_parser.add_argument(
+        "--build-id-pat",
+        default=False,
+        dest="conda_build_build_id_pat",
+        help="""\
+            specify a templated pattern to use as build folder names.  Use if having issues with
+            paths being too long, or to ensure a particular build folder name.
+            When not specified, the default is to use the pattern {n}_{t}.
+            Template variables are: n: package name, t: timestamp, v: package_version""",
+    )
+    conda_build_parser.add_argument(
+        "--no-remove-work-dir",
+        dest="conda_build_remove_work_dir",
+        default=True,
+        action="store_false",
+        help="""\
+            Disable removal of the work dir before testing.  Be careful using this option, as
+            you package may depend on files that are not included in the package, and may pass
+            tests, but ultimately fail on installed systems.""",
+    )
+    conda_build_parser.add_argument(
+        "--keep-old-work",
+        action="store_true",
+        dest="conda_build_keep_old_work",
+        help="Do not remove anything from environment, even after successful build and test.",
+    )
+    conda_build_parser.add_argument(
+        "--prefix-length",
+        dest="conda_build_prefix_length",
+        help="""\
+            length of build prefix.  For packages with binaries that embed the path, this is
+            critical to ensuring that your package can run as many places as possible.  Note
+            that this value can be altered by the OS below boa (e.g. encrypted
+            filesystems on Linux), and you should prefer to set --croot to a non-encrypted
+            location instead, so that you maintain a known prefix length.""",
+        default=255,
+        type=int,
+    )
+    conda_build_parser.add_argument(
+        "--croot",
+        dest="conda_build_croot",
+        help="Build root folder.  Equivalent to CONDA_BLD_PATH, but applies only to this call of `boa build`.",
+    )
+    build_parser.add_argument(
+        "--pkg-format",
+        dest="conda_pkg_format",
+        choices=["1", "2"],
+        default="1",
+        help="Package format version.  Version 1 is the standard .tar.bz2 format.  Version 2 is the new .conda format.",
+    )
+    conda_build_parser.add_argument(
+        "--zstd-compression-level",
+        help="""\
+            When building v2 packages, set the compression level used by
+            conda-package-handling. Defaults to the maximum.""",
+        type=int,
+        choices=range(1, 22),
+        default=22,
+    )
 
     subparsers.add_parser(
         "build",

--- a/boa/core/build.py
+++ b/boa/core/build.py
@@ -280,13 +280,23 @@ def bundle_conda(metadata, initial_files, env, files_selector=None):
     basename = metadata.dist()
     tmp_archives = []
     final_outputs = []
+    cph_kwargs = {}
     ext = ".tar.bz2"
     if output.get("type") == "conda_v2" or metadata.config.conda_pkg_format == "2":
         ext = ".conda"
+        cph_kwargs["compression_tuple"] = (
+            ".tar.zst",
+            "zstd",
+            f"zstd:compression-level={metadata.config.zstd_compression_level}",
+        )
 
     with TemporaryDirectory() as tmp:
         conda_package_handling.api.create(
-            metadata.config.host_prefix, files, basename + ext, out_folder=tmp
+            metadata.config.host_prefix,
+            files,
+            basename + ext,
+            out_folder=tmp,
+            **cph_kwargs,
         )
         tmp_archives = [os.path.join(tmp, basename + ext)]
 

--- a/boa/core/utils.py
+++ b/boa/core/utils.py
@@ -4,6 +4,7 @@
 import collections
 import sys
 import os
+import typing
 
 from conda.base.context import context
 from conda_build import utils
@@ -12,6 +13,11 @@ from conda_build.variants import find_config_files, parse_config_file, combine_s
 from conda_build import __version__ as cb_version
 
 from boa.core.config import boa_config
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+    from conda_build.config import Config as CondaBuildConfig
+
 
 console = boa_config.console
 
@@ -28,12 +34,17 @@ else:
     shell_path = "/bin/bash"
 
 
-def get_config(folder, variant=None, additional_files=None):
+def get_config(
+    folder,
+    variant=None,
+    additional_files=None,
+    config: "CondaBuildConfig | None" = None,
+) -> "tuple[Any, CondaBuildConfig]":
     if not additional_files:
         additional_files = []
     if not variant:
         variant = {}
-    config = get_or_merge_config(None, variant)
+    config = get_or_merge_config(config, variant)
 
     if cb_split_version >= (3, 20, 5):
         config_files = find_config_files(folder, config)

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -31,7 +31,11 @@ def get_outputs(
     recipe = tests_path / folder / recipename
     cbc_file = tests_path / folder / cbcfname
 
-    variant = {"target_platform": "linux-64"}
+    if sys.platform == "win32":
+        variant = {"target_platform": "win-64"}
+    else:
+        variant = {"target_platform": "linux-64"}
+
     cbc, config = get_config(".", variant, [cbc_file])
     cbc["target_platform"] = [variant["target_platform"]]
 


### PR DESCRIPTION
The arguments `--build-id-pat`, `--no-remove-work-dir`, `--keep-old-work`, `--prefix-length`, `--croot` are occasionally used in conjunction with each other in order to ensure a consistent predictable build location that can be used by tools like ccache.

The zstd parameter (and pkg version) configuration option bring boa to parity with conda-build in supporting the `.conda` format