### PR TITLE
Allow `boa build` to support channel pins in packages

### DIFF
--- a/boa/core/metadata.py
+++ b/boa/core/metadata.py
@@ -202,12 +202,28 @@ class MetaData:
                     if self.noarch:
                         continue
 
-            for c in "=!@#$%^&*:;\"'\\|<>?/":
-                if c in spec.name:
+            channel_seperator = "::"
+            channel_seperator_found = channel_seperator in spec.name
+            if channel_seperator_found:
+                channel, _, package = spec.name.partition(channel_seperator)
+                if not channel:
                     sys.exit(
-                        "Error: bad character '%s' in package name "
-                        "dependency '%s'" % (c, spec.name)
+                        f"Error: channel separator '::' found in spec '{spec}' but no channel was specified."
                     )
+                if not package:
+                    sys.exit(
+                        f"Error: channel separator '::' found in spec '{spec}' but no package was specified."
+                    )
+                channel_seperator_found = True
+            else:
+                # since channel names can be full urls many of these characters are potentially valid
+                for c in "=!@#$%^&*;\"'\\|<>?/":
+                    if c in spec.name:
+                        breakpoint()
+                        sys.exit(
+                            "Error: bad character '%s' in package name "
+                            "dependency '%s'" % (c, spec.name)
+                        )
 
             parts = spec.splitted
             if len(parts) >= 2:

--- a/tests/test_boa_build.py
+++ b/tests/test_boa_build.py
@@ -23,7 +23,7 @@ def test_build_notest():
 
 def test_run_exports(tmp_path: Path):
     recipe = tests_dir / "runexports"
-    check_call(["boa", "build", str(recipe), "--output-folder", tmp_path])
+    check_call(["boa", "build", str(recipe), "--output-folder", str(tmp_path)])
 
     rex_a = next(tmp_path.rglob("**/rex-a*.tar.bz2"))
 
@@ -52,7 +52,7 @@ def test_run_exports(tmp_path: Path):
 def test_build_with_channel_pins(tmp_path: Path):
     # Ensure that channel pins round trip correctly
     recipe = tests_dir / "metapackage-channel-pin"
-    check_call(["boa", "build", str(recipe), "--output-folder", tmp_path])
+    check_call(["boa", "build", str(recipe), "--output-folder", str(tmp_path)])
 
     channel_pins = next(tmp_path.rglob("**/metapackage-channel-pin*.tar.bz2"))
 

--- a/tests/test_boa_build.py
+++ b/tests/test_boa_build.py
@@ -1,8 +1,9 @@
 import pathlib
 from subprocess import check_call
-import tempfile
 import tarfile
 import json
+from pathlib import Path
+
 
 recipes_dir = pathlib.Path(__file__).parent / "recipes-v2"
 tests_dir = pathlib.Path(__file__).parent / "tests-v2"
@@ -20,31 +21,41 @@ def test_build_notest():
     check_call(["boa", "build", recipe, "--no-test"])
 
 
-def test_run_exports():
+def test_run_exports(tmp_path: Path):
     recipe = tests_dir / "runexports"
-    with tempfile.TemporaryDirectory() as td:
-        check_call(["boa", "build", str(recipe), "--output-folder", td])
-        output_path = pathlib.Path(td)
+    check_call(["boa", "build", str(recipe), "--output-folder", tmp_path])
 
-        rex_a = next(output_path.rglob("**/rex-a*.tar.bz2"))
+    rex_a = next(tmp_path.rglob("**/rex-a*.tar.bz2"))
 
-        with tarfile.open(rex_a) as fin:
-            rexport = json.load(fin.extractfile("info/run_exports.json"))
-            assert rexport["weak"]
-            assert "strong" not in rexport
-            assert rexport["weak"] == ["rex-exporter 0.1.*"]
+    with tarfile.open(rex_a) as fin:
+        rexport = json.load(fin.extractfile("info/run_exports.json"))
+        assert rexport["weak"]
+        assert "strong" not in rexport
+        assert rexport["weak"] == ["rex-exporter 0.1.*"]
 
-        rex_b = next(output_path.rglob("**/rex-b*.tar.bz2"))
+    rex_b = next(tmp_path.rglob("**/rex-b*.tar.bz2"))
 
-        with tarfile.open(rex_b) as fin:
-            rexport = json.load(fin.extractfile("info/run_exports.json"))
-            assert rexport["weak"]
-            assert rexport["weak"] == ["rex-a 0.1.0.*"]
-            assert rexport["strong"]
-            assert rexport["strong"] == ["rex-exporter 0.1.*"]
+    with tarfile.open(rex_b) as fin:
+        rexport = json.load(fin.extractfile("info/run_exports.json"))
+        assert rexport["weak"]
+        assert rexport["weak"] == ["rex-a 0.1.0.*"]
+        assert rexport["strong"]
+        assert rexport["strong"] == ["rex-exporter 0.1.*"]
 
-        rexporter = next(output_path.rglob("**/rex-exporter*.tar.bz2"))
-        with tarfile.open(rexporter) as fin:
-            names = [x.name for x in fin.getmembers()]
-            print(names)
-            assert "info/run_exports.json" not in names
+    rexporter = next(tmp_path.rglob("**/rex-exporter*.tar.bz2"))
+    with tarfile.open(rexporter) as fin:
+        names = [x.name for x in fin.getmembers()]
+        print(names)
+        assert "info/run_exports.json" not in names
+
+
+def test_build_with_channel_pins(tmp_path: Path):
+    # Ensure that channel pins round trip correctly
+    recipe = tests_dir / "metapackage-channel-pin"
+    check_call(["boa", "build", str(recipe), "--output-folder", tmp_path])
+
+    channel_pins = next(tmp_path.rglob("**/metapackage-channel-pin*.tar.bz2"))
+
+    with tarfile.open(channel_pins) as fin:
+        info = json.load(fin.extractfile("info/index.json"))
+        assert "conda-forge::zlib" in info["depends"]

--- a/tests/test_boa_build.py
+++ b/tests/test_boa_build.py
@@ -58,4 +58,4 @@ def test_build_with_channel_pins(tmp_path: Path):
 
     with tarfile.open(channel_pins) as fin:
         info = json.load(fin.extractfile("info/index.json"))
-        assert "conda-forge::zlib" in info["depends"]
+        assert "pytorch::pytorch" in info["depends"]

--- a/tests/tests-v2/metapackage-channel-pin/recipe.yaml
+++ b/tests/tests-v2/metapackage-channel-pin/recipe.yaml
@@ -1,0 +1,9 @@
+package:
+  name: "metapackage-channel-pin"
+  version: "0.1.0"
+
+build:
+  number: 0
+
+run:
+  - conda-forge::zlib

--- a/tests/tests-v2/metapackage-channel-pin/recipe.yaml
+++ b/tests/tests-v2/metapackage-channel-pin/recipe.yaml
@@ -5,5 +5,6 @@ package:
 build:
   number: 0
 
-run:
-  - conda-forge::zlib
+requirements:
+  run:
+    - pytorch::pytorch


### PR DESCRIPTION
This is a rarely used feature from conda-build that was not working as expected.