### PR TITLE
mambabuild: dependency error parse improvements

### DIFF
--- a/boa/cli/mambabuild.py
+++ b/boa/cli/mambabuild.py
@@ -27,45 +27,53 @@ only_dot_or_digit_re = re.compile(r"^[\d\.]+$")
 
 solver_map = {}
 
+# e.g. package-1.2.3-h5487548_0
+dashed_spec_pattern = r"([^ ]+)-([^- ]+)-([^- ]+)"
+# e.g. package 1.2.8.*
+conda_build_spec_pattern = r"([^ ]+)(?:\ ([^ ]+))?(?:\ ([^ ]+))?"
+
+problem_re = re.compile(
+    rf"""
+        ^(?:\ *-\ +)+
+        (?:
+            (?:
+                package
+                \ {dashed_spec_pattern}
+                \ requires
+                \ {conda_build_spec_pattern}
+                ,\ but\ none\ of\ the\ providers\ can\ be\ installed
+            ) | (?:
+                nothing\ provides
+                \ {conda_build_spec_pattern}
+                \ needed\ by
+                \ {dashed_spec_pattern}
+            ) | (?:
+                nothing\ provides(?:\ requested)?
+                \ {conda_build_spec_pattern}
+            )
+        )
+    """,
+    re.VERBOSE,
+)
+
 
 def parse_problems(problems):
-    dashed_specs = []  # e.g. package-1.2.3-h5487548_0
-    conda_build_specs = []  # e.g. package 1.2.8.*
-
-    for line in problems.splitlines():
-        line = line.strip()
-        if not line.startswith("- "):
-            continue
-        if line.startswith("- - "):
-            line = line[2:]
-        words = line.split()
-        if "none of the providers can be installed" in line:
-            assert words[1] == "package", f"words = {repr(words)}"
-            assert words[3] == "requires", f"words = {repr(words)}"
-            dashed_specs.append(words[2])
-            end = words.index("but")
-            conda_build_specs.append(words[4:end])
-        elif "- nothing provides" in line and "needed by" in line:
-            dashed_specs.append(words[-1])
-        elif "- nothing provides" in line:
-            if "requested" in line:
-                conda_build_specs.append(words[5:])
-            else:
-                conda_build_specs.append(words[4:])
-
     conflicts = {}
-    for conflict in dashed_specs:
-        name, version, build = conflict.rsplit("-", 2)
-        conflicts[name] = MatchSpec(name=name, version=version, build=build)
-
-    for conflict in conda_build_specs:
-        kwargs = {"name": conflict[0]}
-        if len(conflict) >= 2:
-            kwargs["version"] = conflict[1].rstrip(",")
-        if len(conflict) == 3:
-            kwargs["build"] = conflict[2].rstrip(",")
-        conflicts[kwargs["name"]] = MatchSpec(**kwargs)
-
+    for line in problems.splitlines():
+        match = problem_re.match(line)
+        if not match:
+            continue
+        # All capture groups in problem_re only come from dashed_spec_pattern
+        # and conda_build_spec_pattern and thus are always multiples of 3.
+        for name, version, build in zip(*([iter(match.groups())] * 3)):
+            if name is None:
+                continue
+            kwargs = {"name": name}
+            if version is not None:
+                kwargs["version"] = version
+            if build is not None:
+                kwargs["build"] = build
+            conflicts[name] = MatchSpec(**kwargs)
     return set(conflicts.values())
 
 

--- a/boa/cli/mambabuild.py
+++ b/boa/cli/mambabuild.py
@@ -43,6 +43,13 @@ problem_re = re.compile(
                 \ {conda_build_spec_pattern}
                 ,\ but\ none\ of\ the\ providers\ can\ be\ installed
             ) | (?:
+                package
+                \ {dashed_spec_pattern}
+                \ has\ constraint
+                \ .*
+                \ conflicting\ with
+                \ {dashed_spec_pattern}
+            ) | (?:
                 nothing\ provides
                 \ {conda_build_spec_pattern}
                 \ needed\ by

--- a/tests/env.yml
+++ b/tests/env.yml
@@ -2,7 +2,7 @@ name: test
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python>=3.7
   - pip
   - mamba
   - pytest
@@ -13,4 +13,6 @@ dependencies:
   - jsonschema
   - json5
   - beautifulsoup4
+  - prompt-toolkit
+  - watchgod
   - joblib

--- a/tests/recipes/dep_error_has_constaint/meta.yaml
+++ b/tests/recipes/dep_error_has_constaint/meta.yaml
@@ -1,0 +1,8 @@
+package:
+  name: dep_error_has_constraint
+  version: 1.0
+
+requirements:
+  host:
+    - python_abi 3.10
+    - python 3.11

--- a/tests/recipes/dep_error_needed_by/meta.yaml
+++ b/tests/recipes/dep_error_needed_by/meta.yaml
@@ -1,0 +1,15 @@
+{% set name = "dep_error_needed_by" %}
+
+package:
+  name: {{ name }}
+  version: 1.0
+
+outputs:
+  - name: {{ name }}_1
+    requirements:
+      run:
+        - thispackagedoesnotexist
+  - name: {{ name }}_2
+    requirements:
+      host:
+        - {{ name }}_1

--- a/tests/recipes/dep_error_nothing_provides/meta.yaml
+++ b/tests/recipes/dep_error_nothing_provides/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: dep_error_nothing_provides
+  version: 1.0
+
+requirements:
+  host:
+    - thispackagedoesnotexist

--- a/tests/recipes/dep_error_package_requires/meta.yaml
+++ b/tests/recipes/dep_error_package_requires/meta.yaml
@@ -1,0 +1,8 @@
+package:
+  name: dep_error_package_requires
+  version: 1.0
+
+requirements:
+  host:
+    - cython * py310*
+    - python 3.11

--- a/tests/test_mambabuild.py
+++ b/tests/test_mambabuild.py
@@ -1,18 +1,21 @@
 import pytest
+import sys
 from pathlib import Path
-from subprocess import check_call, CalledProcessError
+from queue import Queue
+from subprocess import CalledProcessError, PIPE, Popen, check_call
+from threading import Thread
 
 recipes_dir = Path(__file__).parent / "recipes"
 
-dep_error_recipes = [
-    str(recipes_dir / name) for name in (
-        "baddeps",
-        "dep_error_nothing_provides",
-        "dep_error_needed_by",
-        "dep_error_package_requires",
-        "dep_error_has_constaint",
+dep_error_recipes = {
+    str(recipes_dir / name): deps for name, *deps in (
+        ("baddeps", "thispackagedoesnotexist"),
+        ("dep_error_nothing_provides", "thispackagedoesnotexist"),
+        ("dep_error_needed_by", "thispackagedoesnotexist", "dep_error_needed_by_1"),
+        ("dep_error_package_requires", "python", "cython"),
+        ("dep_error_has_constaint", "python=", "python_abi="),
     )
-]
+}
 recipes = [
     str(x) for x in recipes_dir.iterdir()
     if x.is_dir() and str(x) not in dep_error_recipes
@@ -20,10 +23,49 @@ recipes = [
 notest_recipes = [str(recipes_dir / "baddeps")]
 
 
-@pytest.mark.parametrize("recipe", dep_error_recipes)
-def test_build_dep_error_recipes(recipe):
-    with pytest.raises(CalledProcessError):
-        check_call(["conda", "mambabuild", recipe])
+def dep_error_capture_call(cmd):
+    def capture(pipe, put):
+        err_lines = []
+        for line in iter(pipe.readline, ""):
+            if err_lines or line.startswith(
+                "conda_build.exceptions.DependencyNeedsBuildingError:"
+            ):
+                err_lines.append(line)
+            put(line)
+        put(None)
+        put("".join(err_lines).replace("\n", ""))
+        pipe.close()
+
+    def passthrough(write, get):
+        for line in iter(get, None):
+            write(line)
+
+    process = Popen(cmd, stderr=PIPE, close_fds=True, text=True)
+    queue = Queue()
+    capture_thread = Thread(
+        target=capture, args=(process.stderr, queue.put), daemon=True
+    )
+    passthrough_thread = Thread(
+        target=passthrough, args=(sys.stderr.write, queue.get,), daemon=True
+    )
+    capture_thread.start()
+    passthrough_thread.start()
+    process.wait()
+    capture_thread.join()
+    passthrough_thread.join()
+    if process.returncode:
+        raise CalledProcessError(process.returncode, cmd, None, queue.get())
+
+
+@pytest.mark.parametrize("recipe,deps", dep_error_recipes.items())
+def test_build_dep_error_recipes(recipe, deps):
+    with pytest.raises(CalledProcessError) as exc_info:
+        dep_error_capture_call(
+            ["conda", "mambabuild", recipe]
+        )
+    error = exc_info.value.stderr
+    for dep in deps:
+        assert f'MatchSpec("{dep}' in error
 
 
 @pytest.mark.parametrize("recipe", recipes)

--- a/tests/test_mambabuild.py
+++ b/tests/test_mambabuild.py
@@ -4,18 +4,31 @@ from subprocess import check_call, CalledProcessError
 
 recipes_dir = Path(__file__).parent / "recipes"
 
-recipes = [str(x) for x in recipes_dir.iterdir() if x.is_dir()]
-notest_recipes = [x for x in recipes if Path(x).name in ["baddeps"]]
+dep_error_recipes = [
+    str(recipes_dir / name) for name in (
+        "baddeps",
+        "dep_error_nothing_provides",
+        "dep_error_needed_by",
+        "dep_error_package_requires",
+        "dep_error_has_constaint",
+    )
+]
+recipes = [
+    str(x) for x in recipes_dir.iterdir()
+    if x.is_dir() and str(x) not in dep_error_recipes
+]
+notest_recipes = [str(recipes_dir / "baddeps")]
+
+
+@pytest.mark.parametrize("recipe", dep_error_recipes)
+def test_build_dep_error_recipes(recipe):
+    with pytest.raises(CalledProcessError):
+        check_call(["conda", "mambabuild", recipe])
 
 
 @pytest.mark.parametrize("recipe", recipes)
 def test_build_recipes(recipe):
-    expected_fail_recipes = ["baddeps"]
-    if Path(recipe).name in expected_fail_recipes:
-        with pytest.raises(CalledProcessError):
-            check_call(["conda", "mambabuild", recipe])
-    else:
-        check_call(["conda", "mambabuild", recipe])
+    check_call(["conda", "mambabuild", recipe])
 
 
 @pytest.mark.parametrize("recipe", notest_recipes)


### PR DESCRIPTION
This is a follow-up to gh-301 to fix/improve the dependency extraction in `mambabuild.parse_problems` for different cases.