### PR TITLE
#311 - reverting schema changes

### DIFF
--- a/boa/schemas/model.py
+++ b/boa/schemas/model.py
@@ -37,7 +37,7 @@ class BaseSourceItem(BaseModel):
         extra = Extra.forbid
 
     patches: Optional[List[str]] = None
-    destination: Optional[str] = None
+    folder: Optional[str] = None
 
 
 class UrlSource(BaseSourceItem):

--- a/boa/schemas/recipe.v1.json
+++ b/boa/schemas/recipe.v1.json
@@ -97,8 +97,8 @@
             "type": "string"
           }
         },
-        "destination": {
-          "title": "Destination",
+        "folder": {
+          "title": "Folder",
           "type": "string"
         },
         "url": {
@@ -144,8 +144,8 @@
             "type": "string"
           }
         },
-        "destination": {
-          "title": "Destination",
+        "folder": {
+          "title": "Folder",
           "type": "string"
         },
         "git_rev": {
@@ -179,8 +179,8 @@
             "type": "string"
           }
         },
-        "destination": {
-          "title": "Destination",
+        "folder": {
+          "title": "Folder",
           "type": "string"
         },
         "hg_url": {
@@ -209,8 +209,8 @@
             "type": "string"
           }
         },
-        "destination": {
-          "title": "Destination",
+        "folder": {
+          "title": "Folder",
           "type": "string"
         },
         "svn_url": {
@@ -244,8 +244,8 @@
             "type": "string"
           }
         },
-        "destination": {
-          "title": "Destination",
+        "folder": {
+          "title": "Folder",
           "type": "string"
         },
         "path": {


### PR DESCRIPTION
#311 - fix, sorry commit message has wrong issue id

sources:
  git_url: ..
  destination -> folder:

the actual download of the source is taking place in the conda_build::source.provide.L850 which expects a folder in the schema name

boa::boa.core.build.py:L565
def _try_download(m, interactive):
    try:
        source.provide(m)

conda_build::source.provide.py:L850
             folder = source_dict.get('folder')