### PR TITLE
Fix pin_compatible

### DIFF
--- a/boa/core/recipe_output.py
+++ b/boa/core/recipe_output.py
@@ -512,7 +512,7 @@ class Output:
             specs = self.requirements[env]
 
             for s in specs:
-                if s.is_pin:
+                if s.is_pin_subpackage:
                     s.eval_pin_subpackage(all_outputs)
                 if env == "run" and s.is_pin_compatible:
                     s.eval_pin_compatible(

--- a/tests/recipes-v2/pin_compatible/recipe.yaml
+++ b/tests/recipes-v2/pin_compatible/recipe.yaml
@@ -1,0 +1,15 @@
+context:
+  name: "test_pin_compatible"
+
+package:
+  name: "{{ name }}"
+  version: '1.2.3'
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - numpy >=1.20
+  run:
+    - "{{ pin_compatible('numpy', lower_bound='1.20') }}"


### PR DESCRIPTION
Ran into this issue when I was trying to upgrade to a newer version of boa, going from `0.7.1` directly to `0.14.0` not sure when this stopped working. 

Added test to the boa build recipes. The test is pretty specific to my use case but my knowledge on the pin compatible mechanism is too small to make any more meaning full test. 