### PR TITLE
Support passing build variants from cli

### DIFF
--- a/boa/cli/boa.py
+++ b/boa/cli/boa.py
@@ -161,6 +161,13 @@ def main(config=None):
         default=22,
     )
 
+    for k in ("perl", "lua", "python", "numpy", "r_base"):
+        conda_build_parser.add_argument(
+            "--{}".format(k),
+            dest="{}_variant".format(k),
+            help="Set the {} variant used by conda build.".format(k),
+        )
+
     subparsers.add_parser(
         "build",
         parents=[parent_parser, build_parser, variant_parser],

--- a/boa/core/run_build.py
+++ b/boa/core/run_build.py
@@ -483,6 +483,13 @@ def run_build(args: argparse.Namespace) -> None:
 
     cbc["target_platform"] = [variant["target_platform"]]
 
+    # Command line variant
+    for lang in ("perl", "lua", "python", "numpy", "r_base"):
+        lang_variant = getattr(args, lang + "_variant", None)
+        if lang_variant:
+            cbc[lang] = [lang_variant]
+            variant[lang] = lang_variant
+
     if not os.path.exists(config.output_folder):
         mkdir_p(config.output_folder)
 


### PR DESCRIPTION
This allows passing the variant from the cli to match conda build.

Eg  `boa build recipe --python=3.11` 