### PR TITLE
Implement separate "boa test" command to fix #326

### DIFF
--- a/boa/cli/boa.py
+++ b/boa/cli/boa.py
@@ -65,6 +65,18 @@ def main(config=None):
         help="Validate recipe.yaml",
     )
 
+    test_parser = argparse.ArgumentParser(add_help=False)
+    test_parser.add_argument(
+        "--extra-deps",
+        action="append",
+        help="Extra dependencies to add to all test environment creation steps.",
+    )
+    subparsers.add_parser(
+        "test",
+        parents=[parent_parser, test_parser],
+        help="test an already built package (include_recipe of the package must be true)",
+    )
+
     build_parser = argparse.ArgumentParser(add_help=False)
     build_parser.add_argument(
         "-i",
@@ -201,6 +213,7 @@ def main(config=None):
     from boa.cli import convert
     from boa.cli import transmute
     from boa.cli import validate
+    from boa.cli import test
 
     if command == "convert":
         convert.main(args.target)
@@ -208,6 +221,10 @@ def main(config=None):
 
     if command == "validate":
         validate.main(args.target)
+        exit()
+
+    if command == "test":
+        test.main(args)
         exit()
 
     if command == "transmute":

--- a/boa/cli/test.py
+++ b/boa/cli/test.py
@@ -18,5 +18,5 @@ def main(args):
         stats,
         move_broken=False,
         provision_only=False,
-        extra_deps=getattr(args, "extra_deps", [])
+        extra_deps=getattr(args, "extra_deps", []),
     )

--- a/boa/cli/test.py
+++ b/boa/cli/test.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2021, QuantStack
+# SPDX-License-Identifier: BSD-3-Clause
+from boa.core.run_build import initialize_conda_build_config
+from boa.core.test import run_test
+
+from rich.console import Console
+
+console = Console()
+
+
+def main(args):
+    stats = {}
+    config = initialize_conda_build_config(args)
+
+    run_test(
+        args.target,
+        config,
+        stats,
+        move_broken=False,
+        provision_only=False,
+        extra_deps=getattr(args, "extra_deps", [])
+    )

--- a/boa/core/test.py
+++ b/boa/core/test.py
@@ -653,7 +653,7 @@ def run_test(
     move_broken=True,
     provision_only=False,
     solver=None,
-    extra_deps=[],
+    extra_deps=None,
 ):
     """
     Execute any test scripts for the given package.

--- a/boa/core/test.py
+++ b/boa/core/test.py
@@ -653,6 +653,7 @@ def run_test(
     move_broken=True,
     provision_only=False,
     solver=None,
+    extra_deps=[],
 ):
     """
     Execute any test scripts for the given package.
@@ -754,6 +755,8 @@ def run_test(
     # get_build_metadata(metadata)
 
     specs = metadata.get_test_deps(py_files, pl_files, lua_files, r_files)
+    if extra_deps is not None and len(extra_deps) > 0:
+        specs += extra_deps
 
     tests_metadata = metadata.output.data.get("test")
     exists_metadata = tests_metadata.get("exists", {})


### PR DESCRIPTION
Fixes #326 - `boa test xyz.tar.bz2` can now be used to test a package seperate from the build process.

Also includes an argument "--extra-deps", as known from conda-build, to add additional packages to the testing environment. Use case for that would be for example to a) specify a Python version for a noarch package, or b) first test the package, then use the test environment (e.g. with the --extra-deps mypy & pylint) to run further linting or type checking steps in a CI.