### PR TITLE
Make it possible to include the recipe.yaml inside a pyproject.toml

### DIFF
--- a/boa/cli/boa.py
+++ b/boa/cli/boa.py
@@ -41,6 +41,10 @@ def main(config=None):
     parent_parser.add_argument("--target-platform", type=str)
     parent_parser.add_argument("--json", action="store_true")
     parent_parser.add_argument("--debug", action="store_true")
+    parent_parser.add_argument(
+        "--pyproject-recipes",
+        action="store_true",
+        help="""Use [tool.boa] section from pyproject.toml as a recipe instead of a separate recipe.yaml.""")
 
     variant_parser = argparse.ArgumentParser(add_help=False)
     variant_parser.add_argument(

--- a/boa/cli/boa.py
+++ b/boa/cli/boa.py
@@ -44,7 +44,8 @@ def main(config=None):
     parent_parser.add_argument(
         "--pyproject-recipes",
         action="store_true",
-        help="""Use [tool.boa] section from pyproject.toml as a recipe instead of a separate recipe.yaml.""")
+        help="""Use [tool.boa] section from pyproject.toml as a recipe instead of a separate recipe.yaml.""",
+    )
 
     variant_parser = argparse.ArgumentParser(add_help=False)
     variant_parser.add_argument(

--- a/boa/cli/validate.py
+++ b/boa/cli/validate.py
@@ -12,7 +12,7 @@ console = Console()
 
 def main(recipe):
     cbc, config = get_config(recipe)
-    ydoc = render(recipe, config)
+    ydoc = render(recipe, config, is_pyproject_recipe=recipe.endswith(".toml"))
     console.print("\n\nNormalized Recipe:\n")
     console.print(ydoc)
     try:

--- a/boa/core/render.py
+++ b/boa/core/render.py
@@ -166,15 +166,27 @@ def default_jinja_vars(config):
     return res
 
 
-def render(recipe_path, config=None):
+def render(recipe_path, config=None, is_pyproject_recipe=False):
     # console.print(f"\n[yellow]Rendering {recipe_path}[/yellow]\n")
     # step 1: parse YAML
-    with open(recipe_path) as fi:
-        loader = YAML(typ="safe")
-        ydoc = loader.load(fi)
+    with open(recipe_path, "r") as fi:
+        if is_pyproject_recipe:
+            try:  # Python >=3.11
+                import tomllib
+                ydoc = tomllib.load(fi)
+            except (ModuleNotFoundError, ImportError):  # Python <3.11
+                import toml
+                ydoc = toml.load(fi)
+        else:
+            loader = YAML(typ="safe")
+            ydoc = loader.load(fi)
 
     # step 2: fill out context dict
     context_dict = default_jinja_vars(config)
+    if is_pyproject_recipe:
+        # Use [tool.boa] section from pyproject as a recipe, everything else as the context.
+        context_dict["pyproject"] = ydoc
+        ydoc = ydoc["tool"]["boa"]
     context_dict.update(ydoc.get("context", {}))
     context_dict["environ"] = os.environ
     jenv = jinja2.Environment()

--- a/boa/core/render.py
+++ b/boa/core/render.py
@@ -173,9 +173,11 @@ def render(recipe_path, config=None, is_pyproject_recipe=False):
         if is_pyproject_recipe:
             try:  # Python >=3.11
                 import tomllib
+
                 ydoc = tomllib.load(fi)
-            except (ModuleNotFoundError, ImportError):  # Python <3.11
+            except ImportError:  # Python <3.11
                 import toml
+
                 ydoc = toml.load(fi)
         else:
             loader = YAML(typ="safe")

--- a/boa/core/run_build.py
+++ b/boa/core/run_build.py
@@ -39,17 +39,18 @@ from conda_build.index import update_index
 console = boa_config.console
 
 
-def find_all_recipes(target, config):
+def find_all_recipes(target, config, is_pyproject_recipe=False):
     if os.path.isdir(target):
         cwd = target
     else:
         cwd = os.getcwd()
-    yamls = glob.glob(os.path.join(cwd, "recipe.yaml"))
-    yamls += glob.glob(os.path.join(cwd, "**", "recipe.yaml"))
+    recipe_filename = "pyproject.toml" if is_pyproject_recipe else "recipe.yaml"
+    recipe_files = glob.glob(os.path.join(cwd, recipe_filename))
+    recipe_files += glob.glob(os.path.join(cwd, "**", recipe_filename))
 
     recipes = {}
-    for fn in yamls:
-        yml = render(fn, config=config)
+    for fn in recipe_files:
+        yml = render(fn, config=config, is_pyproject_recipe=is_pyproject_recipe)
 
         try:
             validate(yml)
@@ -195,9 +196,10 @@ def build_recipe(
     skip_fast: bool = False,
     continue_on_failure: bool = False,
     rerun_build: bool = False,
+    pyproject_recipes = False,
 ):
 
-    ydoc = render(recipe_path, config=config)
+    ydoc = render(recipe_path, config=config, is_pyproject_recipe=pyproject_recipes)
     # We need to assemble the variants for each output
     variants = {}
     # if we have a outputs section, use that order the outputs
@@ -496,7 +498,8 @@ def run_build(args: argparse.Namespace) -> None:
     console.print(f"Updating build index: {(config.output_folder)}\n")
     update_index(config.output_folder, verbose=config.debug, threads=1)
 
-    all_recipes = find_all_recipes(args.target, config)  # [noqa]
+    is_pyproject_recipe = getattr(args, "pyproject_recipes", False)
+    all_recipes = find_all_recipes(args.target, config, is_pyproject_recipe)  # [noqa]
 
     console.print("\n[yellow]Assembling all recipes and variants[/yellow]\n")
 
@@ -516,6 +519,7 @@ def run_build(args: argparse.Namespace) -> None:
                     skip_fast=getattr(args, "skip_existing", "default") == "fast",
                     continue_on_failure=getattr(args, "continue_on_failure", False),
                     rerun_build=rerun_build,
+                    pyproject_recipes=getattr(args, "pyproject_recipes", False),
                 )
                 rerun_build = False
             except BoaRunBuildException:

--- a/boa/core/run_build.py
+++ b/boa/core/run_build.py
@@ -196,7 +196,7 @@ def build_recipe(
     skip_fast: bool = False,
     continue_on_failure: bool = False,
     rerun_build: bool = False,
-    pyproject_recipes = False,
+    pyproject_recipes=False,
 ):
 
     ydoc = render(recipe_path, config=config, is_pyproject_recipe=pyproject_recipes)

--- a/boa/core/test.py
+++ b/boa/core/test.py
@@ -52,9 +52,17 @@ console = Console()
 log = logging.getLogger("boa")
 
 
-def get_metadata(yml, config):
+def get_metadata(yml, config, is_pyproject_recipe=False):
     with open(yml, "r") as fi:
-        d = ruamel.yaml.safe_load(fi)
+        if is_pyproject_recipe:
+            try:  # Python >=3.11
+                import tomllib
+                d = tomllib.load(fi)["tool"]["boa"]
+            except (ModuleNotFoundError, ImportError):  # Python <3.11
+                import toml
+                d = toml.load(fi)["tool"]["boa"]
+        else:
+            d = ruamel.yaml.safe_load(fi)
     o = Output(d, config)
     return MetaData(os.path.dirname(yml), o)
 
@@ -307,11 +315,17 @@ def _construct_metadata_for_test_from_package(package, config):
         #     os.path.join(info_dir, "recipe"), config=config, reset_build_id=False
         # )[0][0]
 
-        metadata = get_metadata(recipe_path, config)
-        # with open(os.path.join(info_dir, "recipe", "recipe.yaml")) as fi:
-        # metadata = yaml.load(fi)
+        try:
+            metadata = get_metadata(recipe_path, config)
+            # with open(os.path.join(info_dir, "recipe", "recipe.yaml")) as fi:
+            # metadata = yaml.load(fi)
+        except (SystemExit, FileNotFoundError):
+            # Try if it's a pyproject-based recipe
+            pyproject_path = os.path.join(info_dir, "recipe", "pyproject.toml")
+            metadata = get_metadata(pyproject_path, config, is_pyproject_recipe=True)
+            recipe_path = pyproject_path  # If it was successful, use pyproject.toml path as recipe_path
     # no recipe in package.  Fudge metadata
-    except (SystemExit, FileNotFoundError):
+    except (SystemExit, FileNotFoundError, KeyError):
         # force the build string to line up - recomputing it would
         #    yield a different result
         metadata = MetaData(

--- a/boa/core/test.py
+++ b/boa/core/test.py
@@ -57,9 +57,11 @@ def get_metadata(yml, config, is_pyproject_recipe=False):
         if is_pyproject_recipe:
             try:  # Python >=3.11
                 import tomllib
+
                 d = tomllib.load(fi)["tool"]["boa"]
-            except (ModuleNotFoundError, ImportError):  # Python <3.11
+            except ImportError:  # Python <3.11
                 import toml
+
                 d = toml.load(fi)["tool"]["boa"]
         else:
             d = ruamel.yaml.safe_load(fi)


### PR DESCRIPTION
Instead of having a separate recipe.yaml (which since boa is now valid YAML), this makes it possible to represent a recipe directly inside a pyproject.toml file, which makes it a lot more streamlined to build internal packages where code & recipe are not separated from each other.

This is further explained in and closes #323, and implements only the second example - a `load_toml()` function might be nice as well, but as there's currently AFAIK also not a ``load_yaml()` function anymore in boa due to the new spec, I decided not to pusue that approach further.