### PR TITLE
fix: add cdt_name to config.variants

### DIFF
--- a/boa/core/run_build.py
+++ b/boa/core/run_build.py
@@ -479,6 +479,9 @@ def run_build(args: argparse.Namespace) -> None:
         config.zstd_compression_level = args.zstd_compression_level
 
     cbc, config = get_config(folder, variant, args.variant_config_files, config=config)
+    if config.variant and "cdt_name" in cbc:
+        # HACK: cdt_name is a list
+        config.variant["cdt_name"] = cbc["cdt_name"][0]
 
     if hasattr(args, "output_folder") and args.output_folder:
         config.output_folder = args.output_folder


### PR DESCRIPTION
Fix #284 

As noted in the linked issue, it looks like the config isn't updated with any of the information from the variant config files passed from the command line (at least, not before the call to `find_all_recipes` in `run_build.py`). The current version of the PR fixes the issue of the `cdt_name` not being recognized by just using the first of the resolved variant configs, which may be a hack.