### PR TITLE
Re-enable explanative error reporting

### DIFF
--- a/boa/core/solver.py
+++ b/boa/core/solver.py
@@ -222,13 +222,12 @@ class MambaSolver:
             pstring = "\n".join(["- " + el for el in pstring.split("\n")])
             error_string += f"\nThe reported errors are:\n{pstring}"
 
-            # This might be the cause of segfaults, that's why it's commented out
-            # if (
-            #     hasattr(api_solver, "explain_problems")
-            #     # can cause errors in explain_problems
-            #     and "unsupported request" not in pstring
-            # ):
-            #     error_string += f"\n\n{api_solver.explain_problems()}"
+            if (
+                hasattr(api_solver, "explain_problems")
+                # can cause errors in explain_problems
+                and "unsupported request" not in pstring
+            ):
+                error_string += f"\n\n{api_solver.explain_problems()}"
 
             print(error_string)
             raise RuntimeError("Solver could not find solution." + error_string)


### PR DESCRIPTION
… so that users see more than `nothing provides _python_rc needed by python-3.12.0rc3-rc3_h30d4d87_1_cpython` for Python packages.