### PR TITLE
replacing use of deprecated ruamel.yaml.safe_load

### DIFF
--- a/boa/core/test.py
+++ b/boa/core/test.py
@@ -64,7 +64,7 @@ def get_metadata(yml, config, is_pyproject_recipe=False):
 
                 d = toml.load(fi)["tool"]["boa"]
         else:
-            loader = YAML(typ="safe")
+            loader = YAML(typ="safe", pure=True)
             d = loader.load(fi)
     o = Output(d, config)
     return MetaData(os.path.dirname(yml), o)

--- a/boa/core/test.py
+++ b/boa/core/test.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 import sys
 from conda.core.package_cache_data import PackageCacheData
-import ruamel
+from ruamel.yaml import YAML
 import tempfile
 from pathlib import Path
 from os.path import isdir, join
@@ -64,7 +64,8 @@ def get_metadata(yml, config, is_pyproject_recipe=False):
 
                 d = toml.load(fi)["tool"]["boa"]
         else:
-            d = ruamel.yaml.safe_load(fi)
+            loader = YAML(typ="safe")
+            d = loader.load(fi)
     o = Output(d, config)
     return MetaData(os.path.dirname(yml), o)
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ deps = [
     "jinja2",
     "setuptools",
     "rich",
-    "ruamel.yaml",
+    "ruamel.yaml >=0.18.0",
     "json5",
     "watchgod",
     "prompt-toolkit",


### PR DESCRIPTION
With the latest release of `ruamel.yaml` version `0.18.2`, now `safe_load` is removed. In this PR updating a remaining usage of it.