### PR TITLE
Update for conda/conda-build deprecations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: install mamba
       uses: mamba-org/setup-micromamba@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '*']  # Lowest and unbound version to test for.
         conda-channel: ['conda-forge', 'conda-canary/label/dev']
+        include:
+          # Lowest versions to test for.
+          - conda-channel: 'conda-forge'
+            conda-build-version: '3.25'
+            python-version: '3.8'
+          # Unbound/dev versions to test for.
+          - conda-channel: 'conda-canary/label/dev'
+            conda-build-version: '*'
+            python-version: '*'
     steps:
     - uses: actions/checkout@v2
     - name: install mamba
@@ -28,7 +36,7 @@ jobs:
           --channel-priority=flexible
           python=${{ matrix.python-version }}
           ${{ matrix.conda-channel }}::conda
-          ${{ matrix.conda-channel }}::conda-build
+          ${{ matrix.conda-channel }}::conda-build=${{ matrix.conda-build-version }}
     - name: Install boa
       shell: bash -l {0}
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
             conda-build-version: '*'
             python-version: '*'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: install mamba
       uses: mamba-org/setup-micromamba@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7]
+        python-version: ['3.8', '*']  # Lowest and unbound version to test for.
         conda-channel: ['conda-forge', 'conda-canary/label/dev']
     steps:
     - uses: actions/checkout@v2
@@ -26,6 +26,7 @@ jobs:
         environment-file: tests/env.yml
         create-args: >-
           --channel-priority=flexible
+          python=${{ matrix.python-version }}
           ${{ matrix.conda-channel }}::conda
           ${{ matrix.conda-channel }}::conda-build
     - name: Install boa

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,12 +17,17 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7]
+        conda-channel: ['conda-forge', 'conda-canary/label/dev']
     steps:
     - uses: actions/checkout@v2
     - name: install mamba
       uses: mamba-org/setup-micromamba@v1
       with:
         environment-file: tests/env.yml
+        create-args: >-
+          --channel-priority=flexible
+          ${{ matrix.conda-channel }}::conda
+          ${{ matrix.conda-channel }}::conda-build
     - name: Install boa
       shell: bash -l {0}
       run: |

--- a/boa/cli/boa.py
+++ b/boa/cli/boa.py
@@ -4,6 +4,8 @@
 import sys
 import argparse
 
+from conda.base.context import context
+
 from boa.core import monkey_patch_emscripten
 
 if any("emscripten" in arg for arg in sys.argv):
@@ -14,7 +16,7 @@ from boa.core.config import init_global_config
 from boa._version import __version__
 from boa.core.utils import init_api_context
 
-from conda_build.conda_interface import cc_conda_build
+cc_conda_build = context.conda_build if hasattr(context, "conda_build") else {}
 
 banner = r"""
            _

--- a/boa/core/build.py
+++ b/boa/core/build.py
@@ -25,7 +25,7 @@ import encodings.idna  # NOQA
 import conda_package_handling.api
 
 # used to get version
-from conda_build.conda_interface import env_path_backup_var_exists, TemporaryDirectory
+from conda.gateways.disk.create import TemporaryDirectory
 from conda_build.utils import tmp_chdir
 
 from conda_build import source, utils
@@ -44,7 +44,11 @@ import conda_build.noarch_python as noarch_python
 if sys.platform == "win32":
     import boa.core.windows as windows
 
-from boa.core.utils import shell_path, get_sys_vars_stubs
+from boa.core.utils import (
+    env_path_backup_var_exists,
+    get_sys_vars_stubs,
+    shell_path,
+)
 from boa.core.recipe_handling import copy_recipe
 from boa.core.config import boa_config
 from boa.tui.exceptions import BoaRunBuildException

--- a/boa/core/metadata.py
+++ b/boa/core/metadata.py
@@ -149,7 +149,7 @@ class MetaData:
             if autotype and default is None and FIELDS.get(section, {}).get(key):
                 default = FIELDS[section][key]()
 
-        section = self.output.sections.get(section, {})
+        section = self.meta.get(section, {})
         if isinstance(section, list):
             return section[int(num)].get(key, default)
         else:

--- a/boa/core/monkey_patch_emscripten.py
+++ b/boa/core/monkey_patch_emscripten.py
@@ -32,8 +32,9 @@ def patch():
     # CONDA-BUILD MONKEY-PATCH
     ###############################################
 
+    from conda.base.context import non_x86_machines as non_x86_linux_machines
+
     from conda_build import utils, variants, environ
-    from conda_build.conda_interface import non_x86_linux_machines
     from conda_build import metadata
     from conda_build.features import feature_list
 

--- a/boa/core/solver.py
+++ b/boa/core/solver.py
@@ -4,12 +4,13 @@
 import os
 import tempfile
 
+from boltons.setutils import IndexedSet
+
 from conda.base.constants import ChannelPriority
 from conda.core.solve import diff_for_unlink_link_precs
 from conda.common.serialize import json_dump
 from conda.models.prefix_graph import PrefixGraph
 from conda.core.prefix_data import PrefixData
-from conda._vendor.boltons.setutils import IndexedSet
 from conda.models.match_spec import MatchSpec
 from conda.common.url import remove_auth, split_anaconda_token
 from conda.core.index import _supplement_index_with_system

--- a/boa/core/solver.py
+++ b/boa/core/solver.py
@@ -15,12 +15,16 @@ from conda.models.match_spec import MatchSpec
 from conda.common.url import remove_auth, split_anaconda_token
 from conda.core.index import _supplement_index_with_system
 from conda.base.context import context
-from conda_build.conda_interface import pkgs_dirs
 from conda.core.package_cache_data import PackageCacheData
 
 import libmambapy
 
-from boa.core.utils import get_index, load_channels, to_package_record_from_subjson
+from boa.core.utils import (
+    get_index,
+    load_channels,
+    pkgs_dirs,
+    to_package_record_from_subjson,
+)
 from boa.core.config import boa_config
 
 console = boa_config.console

--- a/boa/core/test.py
+++ b/boa/core/test.py
@@ -710,7 +710,10 @@ def run_test(
         not hasattr(recipedir_or_package_or_metadata, "config")
         and os.path.isfile(recipedir_or_package_or_metadata)
         and recipedir_or_package_or_metadata.endswith(CONDA_PACKAGE_EXTENSIONS)
-        and os.path.dirname(recipedir_or_package_or_metadata) in pkgs_dirs[0]
+        and any(
+            os.path.dirname(recipedir_or_package_or_metadata) in pkgs_dir
+            for pkgs_dir in pkgs_dirs
+        )
     )
     if not in_pkg_cache:
         clean_pkg_cache(metadata.dist(), metadata.config)

--- a/boa/core/test.py
+++ b/boa/core/test.py
@@ -16,6 +16,7 @@ from boa.core.solver import get_solver
 from libmambapy import PrefixData
 from libmambapy import Context as MambaContext
 
+from conda.common.url import path_to_url
 from conda.gateways.disk.create import mkdir_p
 
 from conda_build.utils import CONDA_PACKAGE_EXTENSIONS, get_site_packages
@@ -24,11 +25,6 @@ from conda_build.build import (
     create_info_files,
     get_all_replacements,
     log_stats,
-)
-from conda_build.conda_interface import (
-    url_path,
-    env_path_backup_var_exists,
-    pkgs_dirs,
 )
 from conda_build.create_test import create_all_test_files
 from conda_build.post import post_build
@@ -40,7 +36,7 @@ from conda_index.index import update_index
 from conda_build import utils
 from conda_build.environ import clean_pkg_cache
 
-from boa.core.utils import shell_path
+from boa.core.utils import env_path_backup_var_exists, pkgs_dirs, shell_path
 from boa.core.recipe_output import Output
 from boa.core.metadata import MetaData
 from boa.core import environ
@@ -359,7 +355,7 @@ def _construct_metadata_for_test_from_package(package, config):
 
     metadata.config.used_vars = list(hash_input.keys())
     urls = list(utils.ensure_list(metadata.config.channel_urls))
-    local_path = url_path(local_channel)
+    local_path = path_to_url(local_channel)
     # replace local with the appropriate real channel.  Order is maintained.
     urls = [url if url != "local" else local_path for url in urls]
     if local_path not in urls:

--- a/boa/core/utils.py
+++ b/boa/core/utils.py
@@ -14,7 +14,6 @@ from conda.base.context import context
 from conda_build import utils
 from conda_build.config import get_or_merge_config
 from conda_build.variants import find_config_files, parse_config_file, combine_specs
-from conda_build import __version__ as cb_version
 from conda.base.constants import ChannelPriority
 from conda.gateways.connection.session import CondaHttpAuth
 from conda.core.index import check_allowlist
@@ -32,11 +31,6 @@ if typing.TYPE_CHECKING:
 
 
 console = boa_config.console
-
-if "+" in cb_version:
-    cb_version = cb_version[: cb_version.index("+")]
-cb_split_version = tuple(int(x) for x in cb_version.split("."))
-
 
 if "bsd" in sys.platform:
     shell_path = "/bin/sh"
@@ -58,11 +52,7 @@ def get_config(
         variant = {}
     config = get_or_merge_config(config, variant)
 
-    if cb_split_version >= (3, 20, 5):
-        config_files = find_config_files(folder, config)
-    else:
-        config_files = find_config_files(folder)
-
+    config_files = find_config_files(folder, config)
     all_files = [os.path.abspath(p) for p in config_files + additional_files]
 
     # reverse files an uniquify

--- a/boa/core/utils.py
+++ b/boa/core/utils.py
@@ -32,6 +32,9 @@ if typing.TYPE_CHECKING:
 
 console = boa_config.console
 
+env_path_backup_var_exists = os.environ.get("CONDA_PATH_BACKUP", None)
+pkgs_dirs = list(context.pkgs_dirs)
+
 if "bsd" in sys.platform:
     shell_path = "/bin/sh"
 elif utils.on_win:

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ deps = [
     "prompt-toolkit",
     "joblib",
     "beautifulsoup4",
+    "boltons",
 ]
 
 setup(

--- a/tests/env.yml
+++ b/tests/env.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python>=3.7
   - pip
+  - boltons
   - conda
   - libmambapy >=1.5,<1.6
   - pytest

--- a/tests/env.yml
+++ b/tests/env.yml
@@ -8,7 +8,7 @@ dependencies:
   - conda
   - libmambapy >=1.5,<1.6
   - pytest
-  - "conda-build>=3.20"
+  - conda-build >=3.25
   - conda-index
   - ruamel
   - ruamel.yaml


### PR DESCRIPTION
This updates `boa` for compatibility with current/upcoming `conda-build` versions.
Overview:
- Add/change CI jobs to test against lowest supported as well as `conda`/`conda-build` pre-release versions.
- Add `boltons` dependency since `conda._vendor.boltons` is being removed.
- Raise minimum `conda-build` to `3.25` (semi-arbitrarily chosen; `>=3.25` include, e.g., fixes for [downstream tests](https://github.com/conda/conda-build/issues/4750)).
- Removes usage of to-be-deprecated `conda_build.conda_interface`.
- Fixes gh-388 .